### PR TITLE
Fix crash when nullptr is passed to DetourNavigation::removeAgent

### DIFF
--- a/src/detournavigation.cpp
+++ b/src/detournavigation.cpp
@@ -429,7 +429,10 @@ DetourNavigation::removeAgent(Ref<DetourCrowdAgent> agent)
 
     // Agents should not be removed while the nav thread is busy
     // Thus this function is used instead of exposing destroy() to GDScript
-    agent->destroy();
+    if (agent != nullptr)
+    {
+      agent->destroy();
+    }
 
     // Remove from the vector
     for (int i = 0; i < _agents.size(); ++i)


### PR DESCRIPTION
Fixes a hard-crash that would occur when a nullptr was passed to `DetourNavigation::removeAgent(Ref<DetourCrowdAgent> agent)`, which would then attempt to call `DetourCrowdAgent::destroy()` on it.

I encountered this crash when destroying an agent that was in an invalid state (e.g. not close enough to the navigation mesh for `dtNavMeshQuery::findNearestPoly` to return a result).